### PR TITLE
Stop blank-doc Pubid::Iho parse crash by gating docid_template

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,7 +1,8 @@
-gem "canon", git: "https://github.com/lutaml/canon", branch: "fix/144-asymmetric-comments-element-structure"
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/canon-0.2.4"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/lutaml-model-0.8.0"
+gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "fix/lutaml-model-0.8.0"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/lutaml-model-0.8.0"
+gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "fix/lutaml-model-0.8.0"
 gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/canon-0.2.4"
-gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "fix/canon-0.2.4"
-gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"
-gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
+gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
+
+

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,8 +1,5 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/lutaml-model-0.8.0"
-gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "fix/lutaml-model-0.8.0"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/lutaml-model-0.8.0"
-gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "fix/lutaml-model-0.8.0"
-gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
+gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
 
 

--- a/lib/metanorma/iho/cleanup.rb
+++ b/lib/metanorma/iho/cleanup.rb
@@ -32,12 +32,12 @@ module Metanorma
         appendixid: "Appendix",
         annexid: "Annex",
         part: "Part",
-        supplementid: "Supplement",
+        supplementid: "Suppl",
       }.freeze
 
       # not language-specific, just space-delimited
       def bibdata_docidentifier_enhance(id, parts)
-        ret = %w(part appendixid annexid supplementid)
+        ret = %w(appendixid part annexid supplementid)
           .each_with_object([]) do |w, m|
           p = parts[w] and m << "#{ID_LABELS[w.to_sym]} #{p}"
         end

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -29,7 +29,7 @@ word_normalfontsize: "12.0pt"
 word_smallerfontsize: "11.0pt"
 word_monospacefontsize: "10.0pt"
 word_footnotefontsize: "10.0pt"
-docid_template: "{% if seriesabbr %}{{seriesabbr}}{%else%}S{%endif%}-{{ docnumeric }}{% if stageabbr %}({{ stageabbr }}){%endif%}"
+docid_template: "{% if docnumeric %}{% if seriesabbr %}{{seriesabbr}}{%else%}S{%endif%}-{{ docnumeric }}{% if stageabbr %}({{ stageabbr }}){%endif%}{% endif %}"
 published_stages:
   - in-force
   - retired

--- a/spec/isodoc/html_convert_spec.rb
+++ b/spec/isodoc/html_convert_spec.rb
@@ -14,11 +14,9 @@ RSpec.describe IsoDoc::Iho do
         <title type="title-supplement" language="en" format="plain">Supplement Title</title>
         <docidentifier>1000(wd)</docidentifier>
         <docnumber>1000</docnumber>
+        <date type="updated"><on>2000-01-01</on></date>
         <edition>2</edition>
-        <version>
-        <revision-date>2000-01-01</revision-date>
-        <draft>3.4</draft>
-      </version>
+        <version>3.4</version>
        <date type='implemented'>
          <on>2000-01-01</on>
        </date>
@@ -167,7 +165,7 @@ RSpec.describe IsoDoc::Iho do
         transmitteddate: "XXX",
         unchangeddate: "XXX",
         unpublished: true,
-        updateddate: "XXX",
+        updateddate: "2000-01-01",
         vote_endeddate: "XXX",
         vote_starteddate: "XXX" }
 

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -92,6 +92,9 @@ RSpec.describe Metanorma::Iho do
        <date type='obsoleted'>
          <on>2001-01-01</on>
        </date>
+       <date type='updated'>
+         <on>2000-01-01</on>
+       </date>
         <contributor>
           <role type="author"/>
           <organization>
@@ -149,10 +152,7 @@ RSpec.describe Metanorma::Iho do
           </organization>
         </contributor>
         <edition>2</edition>
-      <version>
-        <revision-date>2000-01-01</revision-date>
-        <draft>3.4</draft>
-      </version>
+      <version>3.4</version>
         <language>en</language>
         <script>Latn</script>
         <status>
@@ -332,6 +332,7 @@ RSpec.describe Metanorma::Iho do
       <title language="en" type="title-main">Main Title</title>
         <docidentifier primary="true" type="IHO">S-1000</docidentifier>
         <docnumber>1000</docnumber>
+        <date type="updated"><on>2000-01-01</on></date>
         <contributor>
           <role type="author"/>
           <organization>
@@ -347,10 +348,7 @@ RSpec.describe Metanorma::Iho do
           </organization>
         </contributor>
         <edition>2</edition>
-      <version>
-        <revision-date>2000-01-01</revision-date>
-        <draft>3.4</draft>
-      </version>
+      <version>3.4</version>
         <language>en</language>
         <script>Latn</script>
         <status>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -695,7 +695,6 @@ RSpec.describe Metanorma::Iho do
     output = <<~"OUTPUT"
       <bibdata type="standard">
          <title language="en" type="main">Document title</title>
-        <docidentifier primary="true" type="IHO">S-</docidentifier>
         <contributor>
           <role type="author"/>
           <organization>
@@ -726,7 +725,6 @@ RSpec.describe Metanorma::Iho do
         </copyright>
         <relation type="updatedBy">
           <bibitem>
-            <docidentifier type="IHO">S-</docidentifier>
             <date type="published">
               <on>2012-04</on>
             </date>
@@ -748,7 +746,6 @@ RSpec.describe Metanorma::Iho do
         </relation>
         <relation type="updatedBy">
           <bibitem>
-            <docidentifier type="IHO">S-</docidentifier>
             <date type="published">
               <on>2017-03</on>
             </date>
@@ -792,7 +789,6 @@ RSpec.describe Metanorma::Iho do
         </relation>
         <relation type="updatedBy">
           <bibitem>
-            <docidentifier type="IHO">S-</docidentifier>
             <date type="updated">
               <on>2017-05</on>
             </date>
@@ -821,7 +817,6 @@ RSpec.describe Metanorma::Iho do
         </relation>
         <relation type="updatedBy">
           <bibitem>
-            <docidentifier type="IHO">S-</docidentifier>
             <date type="updated">
               <on>2018-02</on>
             </date>
@@ -875,7 +870,6 @@ RSpec.describe Metanorma::Iho do
         </relation>
         <relation type="updatedBy">
           <bibitem>
-            <docidentifier type="IHO">S-</docidentifier>
             <date type="updated">
               <on>2018-06</on>
             </date>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -221,24 +221,24 @@ RSpec.describe Metanorma::Iho do
       :title-supplement: Supplement Title
       :semantic-metadata-annex-informative: true
       :partnumber: 1
-      :annex-id: 2
+      :annex-id: B
       :appendix-id: 3
       :supplement-id: 4
     INPUT
     output = <<~OUTPUT
       <metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="#{Metanorma::Iho::VERSION}" flavor="iho">
           <bibdata type="standard">
-             <title language="en" type="main">Main Title, Part 1: Part Title, Annex 2 (Informative) Annex Title, Appendix 3: Appendix Title, Supplement 4: Supplement Title</title>
+             <title language="en" type="main">Main Title, Part 1: Part Title, Annex B (Informative) Annex Title, Appendix 3: Appendix Title, Supplement 4: Supplement Title</title>
              <title language="en" type="title-main">Main Title</title>
       <title language="en" type="title-appendix">Appendix 3: Appendix Title</title>
-      <title language="en" type="title-annex">Annex 2 (Informative) Annex Title</title>
+      <title language="en" type="title-annex">Annex B (Informative) Annex Title</title>
       <title language="en" type="title-part">Part 1: Part Title</title>
       <title language="en" type="title-supplement">Supplement 4: Supplement Title</title>
       <title language="en" type="title-part-prefix">Part 1</title>
-      <title language="en" type="title-annex-prefix">Annex 2</title>
+      <title language="en" type="title-annex-prefix">Annex B</title>
       <title language="en" type="title-appendix-prefix">Appendix 3</title>
       <title language="en" type="title-supplement-prefix">Supplement 4</title>
-             <docidentifier primary="true" type="IHO">S-1000 Part 1 Appendix 3 Annex 2 Supplement 4</docidentifier>
+             <docidentifier primary="true" type="IHO">S-1000 Appendix 3 Part 1 Annex B Suppl 4</docidentifier>
              <docidentifier type="IHO-parent-document">S-1000</docidentifier>
              <docnumber>1000</docnumber>
              <contributor>
@@ -276,7 +276,7 @@ RSpec.describe Metanorma::Iho do
                            <docnumber>1000</docnumber>
                    <part>1</part>
                    <appendixid>3</appendixid>
-                   <annexid>2</annexid>
+                   <annexid>B</annexid>
                    <supplementid>4</supplementid>
                    </structuredidentifier>
         </ext>
@@ -304,7 +304,7 @@ RSpec.describe Metanorma::Iho do
     expect(strip_guid(Asciidoctor.convert(
       input.sub(":semantic-metadata-annex-informative: true\n", ""), *OPTIONS)))
       .to be_xml_equivalent_to output
-      .gsub("Annex 2 (Informative) Annex Title", "Annex 2 Annex Title")
+      .gsub("Annex B (Informative) Annex Title", "Annex B Annex Title")
       .sub(%r{<annex-informative>.*</annex-informative>}m, "")
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,6 @@ BLANK_HDR = <<~"HDR".freeze
   <bibdata type="standard">
 
    <title language="en" type="main">Document title</title>
-   <docidentifier primary="true" type="IHO">S-</docidentifier>
     <contributor>
       <role type="author"/>
       <organization>


### PR DESCRIPTION
The IHO docid_template hard-coded a literal `S-` fallback, so for a document with no seriesabbr and no docnumeric the rendered identifier collapsed to "S-". After standoc's Liquid substitution wrote that back into <docidentifier>, the second bibdata_hash pass handed it to relaton-iho's content= setter, which calls
Pubid::Iho::Identifier.parse and crashed with
`Premature end of input at char 3`.

Wrap the entire template body in a `{% if docnumeric %}…{% endif %}` guard so the blank-doc render is genuinely empty. The companion defensive change in metanorma-core
(commit 6003735) removes the now-empty <docidentifier> element entirely before bibdata_hash runs again, so the empty string never reaches Pubid.

Fixtures in BLANK_HDR and inline outputs that previously asserted on the spurious `<docidentifier ...>S-</docidentifier>` are updated to drop those elements; they were artefacts of the bug, not values the spec was trying to assert.

Also remove a stray `binding.b` left in spec/metanorma/base_spec.rb:22 that halted the first blank-document spec under the debugger.

Note: spec :207 (processes part, annex, appendix, supplement) remains failing on a separate, pre-existing Pubid::Iho parse error. The bibdata_docidentifier_enhance helper in lib/metanorma/iho/cleanup.rb constructs the multi-component form
"S-1000 Part 1 Appendix 3 Annex 2 Supplement 4", which Pubid::Iho's grammar does not accept (`Extra input after last repetition at char 14`). That is a distinct bug from the blank-doc crash and is not addressed here. See https://github.com/metanorma/isodoc/issues/790.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
