### PR TITLE
Align IHO docidentifier component order with Pubid::Iho grammar

### DIFF
--- a/lib/metanorma/iho/cleanup.rb
+++ b/lib/metanorma/iho/cleanup.rb
@@ -32,12 +32,12 @@ module Metanorma
         appendixid: "Appendix",
         annexid: "Annex",
         part: "Part",
-        supplementid: "Supplement",
+        supplementid: "Suppl",
       }.freeze
 
       # not language-specific, just space-delimited
       def bibdata_docidentifier_enhance(id, parts)
-        ret = %w(part appendixid annexid supplementid)
+        ret = %w(appendixid part annexid supplementid)
           .each_with_object([]) do |w, m|
           p = parts[w] and m << "#{ID_LABELS[w.to_sym]} #{p}"
         end

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -221,24 +221,24 @@ RSpec.describe Metanorma::Iho do
       :title-supplement: Supplement Title
       :semantic-metadata-annex-informative: true
       :partnumber: 1
-      :annex-id: 2
+      :annex-id: B
       :appendix-id: 3
       :supplement-id: 4
     INPUT
     output = <<~OUTPUT
       <metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="#{Metanorma::Iho::VERSION}" flavor="iho">
           <bibdata type="standard">
-             <title language="en" type="main">Main Title, Part 1: Part Title, Annex 2 (Informative) Annex Title, Appendix 3: Appendix Title, Supplement 4: Supplement Title</title>
+             <title language="en" type="main">Main Title, Part 1: Part Title, Annex B (Informative) Annex Title, Appendix 3: Appendix Title, Supplement 4: Supplement Title</title>
              <title language="en" type="title-main">Main Title</title>
       <title language="en" type="title-appendix">Appendix 3: Appendix Title</title>
-      <title language="en" type="title-annex">Annex 2 (Informative) Annex Title</title>
+      <title language="en" type="title-annex">Annex B (Informative) Annex Title</title>
       <title language="en" type="title-part">Part 1: Part Title</title>
       <title language="en" type="title-supplement">Supplement 4: Supplement Title</title>
       <title language="en" type="title-part-prefix">Part 1</title>
-      <title language="en" type="title-annex-prefix">Annex 2</title>
+      <title language="en" type="title-annex-prefix">Annex B</title>
       <title language="en" type="title-appendix-prefix">Appendix 3</title>
       <title language="en" type="title-supplement-prefix">Supplement 4</title>
-             <docidentifier primary="true" type="IHO">S-1000 Part 1 Appendix 3 Annex 2 Supplement 4</docidentifier>
+             <docidentifier primary="true" type="IHO">S-1000 Appendix 3 Part 1 Annex B Suppl 4</docidentifier>
              <docidentifier type="IHO-parent-document">S-1000</docidentifier>
              <docnumber>1000</docnumber>
              <contributor>
@@ -276,7 +276,7 @@ RSpec.describe Metanorma::Iho do
                            <docnumber>1000</docnumber>
                    <part>1</part>
                    <appendixid>3</appendixid>
-                   <annexid>2</annexid>
+                   <annexid>B</annexid>
                    <supplementid>4</supplementid>
                    </structuredidentifier>
         </ext>
@@ -304,7 +304,7 @@ RSpec.describe Metanorma::Iho do
     expect(strip_guid(Asciidoctor.convert(
       input.sub(":semantic-metadata-annex-informative: true\n", ""), *OPTIONS)))
       .to be_xml_equivalent_to output
-      .gsub("Annex 2 (Informative) Annex Title", "Annex 2 Annex Title")
+      .gsub("Annex B (Informative) Annex Title", "Annex B Annex Title")
       .sub(%r{<annex-informative>.*</annex-informative>}m, "")
   end
 


### PR DESCRIPTION
Align `bibdata_docidentifier_enhance` output with the Pubid::Iho grammar so the multi-component IHO docidentifier round-trips through `Pubid::Iho::Identifier.parse`.

Diagnosis and full narrative: https://github.com/metanorma/isodoc/issues/790
