### PR TITLE
Bundle explicit MathML grammar (basicdoc-models#35)

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Bridge: until metanorma-standoc is released with the MathML grammar fix
+# (id_check: false for the jing ID-type conflict; basicdoc-models#35), pin to
+# standoc main. Remove this and bump the released standoc version on release.
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"

--- a/lib/metanorma/iho/basicdoc.rng
+++ b/lib/metanorma/iho/basicdoc.rng
@@ -1902,14 +1902,39 @@ or as the string "auto"</a:documentation>
     <a:documentation>Mathematically formatted text</a:documentation>
     <element name="stem">
       <ref name="StemAttributes"/>
-      <oneOrMore>
-        <choice>
+      <optional>
+        <text>
           <a:documentation>The content of the mathematically formatted text</a:documentation>
-          <text/>
-          <ref name="AnyElement"/>
-        </choice>
-      </oneOrMore>
+        </text>
+      </optional>
+      <optional>
+        <ref name="mathml"/>
+      </optional>
+      <optional>
+        <ref name="asciimath"/>
+      </optional>
+      <optional>
+        <ref name="latexmath"/>
+      </optional>
     </element>
+  </define>
+  <define name="latexmath">
+    <a:documentation>Encoding of LatexMath</a:documentation>
+    <element name="latexmath">
+      <text/>
+    </element>
+  </define>
+  <define name="asciimath">
+    <a:documentation>Encoding of AsciiMath</a:documentation>
+    <element name="asciimath">
+      <text/>
+    </element>
+  </define>
+  <define name="mathml">
+    <a:documentation>Encoding of MathML: the official W3C MathML 3.0 grammar (namespace
+http://www.w3.org/1998/Math/MathML), via the metanorma wrapper in
+grammars/mathml/. See grammars/mathml/README.adoc and basicdoc-models#35.</a:documentation>
+    <externalRef href="metanorma-mathml.rng"/>
   </define>
   <define name="StemAttributes">
     <attribute name="type">

--- a/lib/metanorma/iho/isodoc.rng
+++ b/lib/metanorma/iho/isodoc.rng
@@ -852,7 +852,7 @@ titlecase, or lowercase</a:documentation>
         <a:documentation>Width of the figure block in rendering</a:documentation>
       </attribute>
     </optional>
-    <ref name="BlockAttributes"/>
+    <ref name="BlockAttributesCore"/>
   </define>
   <define name="SourceAttributes" combine="interleave">
     <ref name="BlockAttributes"/>
@@ -1283,7 +1283,11 @@ That concept may be defined as a term within the current document, or it may be 
           <a:documentation>Class of input form</a:documentation>
         </attribute>
       </optional>
-      <ref name="BlockAttributes"/>
+      <ref name="BlockAttributesCore">
+        <a:documentation>form declares its own class above, so it uses BlockAttributesCore to
+avoid duplicating the custom-class slot in BlockAttributes. Treated like
+figure. See metanorma/metanorma-standoc#1197</a:documentation>
+      </ref>
       <zeroOrMore>
         <!-- Input form contents -->
         <choice>
@@ -2768,7 +2772,11 @@ links within an SVG file, so that the SVG file can hyperlink to anchors within t
       </oneOrMore>
     </element>
   </define>
-  <define name="BlockAttributes">
+  <define name="BlockAttributesCore">
+    <a:documentation>Block attributes excluding the custom CSS class. Blocks that already carry
+their own `class` attribute (e.g. figure, via basicdoc FigureAttributes)
+include this directly, to avoid a duplicate-attribute collision with the
+`class` added in BlockAttributes. See metanorma/metanorma-standoc#1197</a:documentation>
     <optional>
       <attribute name="keep-with-next">
         <a:documentation>Keep this block on the same page as the following block in paged media</a:documentation>
@@ -2797,6 +2805,17 @@ links within an SVG file, so that the SVG file can hyperlink to anchors within t
         <a:documentation>Set the columns display of the current block, overriding the display inherited from the document.
 For example, if the document is set to two-column, this attribute would be used to set the block
 to span across both columns</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <define name="BlockAttributes">
+    <a:documentation>Universal block attributes, including a custom CSS class (space-separated,
+appended additively to the block's built-in HTML class, HTML output only).
+See metanorma/metanorma-standoc#1197</a:documentation>
+    <ref name="BlockAttributesCore"/>
+    <optional>
+      <attribute name="class">
+        <a:documentation>Custom CSS class(es) for the block in HTML output</a:documentation>
       </attribute>
     </optional>
   </define>

--- a/lib/metanorma/iho/mathml3-common.rng
+++ b/lib/metanorma/iho/mathml3-common.rng
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="math"/>
+  </start>
+  <define name="math">
+    <element name="math">
+      <ref name="math.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="MathExpression">
+    <ref name="semantics"/>
+  </define>
+  <define name="NonMathMLAtt">
+    <attribute>
+      <anyName>
+        <except>
+          <nsName ns=""/>
+          <nsName/>
+        </except>
+      </anyName>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="CommonDeprecatedAtt">
+    <optional>
+      <attribute name="other"/>
+    </optional>
+  </define>
+  <define name="CommonAtt">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xref"/>
+    </optional>
+    <optional>
+      <attribute name="class">
+        <data type="NMTOKENS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="style">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="href">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <ref name="CommonDeprecatedAtt"/>
+    <zeroOrMore>
+      <ref name="NonMathMLAtt"/>
+    </zeroOrMore>
+  </define>
+  <define name="math.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <attribute name="display">
+        <choice>
+          <value>block</value>
+          <value>inline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxwidth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="overflow">
+        <choice>
+          <value>linebreak</value>
+          <value>scroll</value>
+          <value>elide</value>
+          <value>truncate</value>
+          <value>scale</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-valign">
+        <choice>
+          <ref name="length"/>
+          <value>top</value>
+          <value>middle</value>
+          <value>bottom</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alttext"/>
+    </optional>
+    <optional>
+      <attribute name="cdgroup">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <ref name="math.deprecatedattributes"/>
+  </define>
+  <!--
+    the mathml3-presentation schema  adds additional attributes
+    to the math element, all those valid on mstyle
+  -->
+  <define name="math.deprecatedattributes">
+    <optional>
+      <attribute name="mode">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="macros">
+        <data type="string"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="name">
+    <attribute name="name">
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="cd">
+    <attribute name="cd">
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="src">
+    <optional>
+      <attribute name="src">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="annotation">
+    <element name="annotation">
+      <ref name="annotation.attributes"/>
+      <text/>
+    </element>
+  </define>
+  <define name="annotation-xml.model">
+    <zeroOrMore>
+      <choice>
+        <ref name="MathExpression"/>
+        <ref name="anyElement"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="anyElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName/>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="annotation-xml">
+    <element name="annotation-xml">
+      <ref name="annotation.attributes"/>
+      <ref name="annotation-xml.model"/>
+    </element>
+  </define>
+  <define name="annotation.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <ref name="cd"/>
+    </optional>
+    <optional>
+      <ref name="name"/>
+    </optional>
+    <ref name="DefEncAtt"/>
+    <optional>
+      <ref name="src"/>
+    </optional>
+  </define>
+  <define name="DefEncAtt">
+    <optional>
+      <attribute name="encoding">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="definitionURL">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="semantics">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <ref name="MathExpression"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="semantics.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="DefEncAtt"/>
+    <optional>
+      <ref name="cd"/>
+    </optional>
+    <optional>
+      <ref name="name"/>
+    </optional>
+  </define>
+  <define name="length">
+    <data type="string">
+      <param name="pattern">\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*</param>
+    </data>
+  </define>
+</grammar>

--- a/lib/metanorma/iho/mathml3-content.rng
+++ b/lib/metanorma/iho/mathml3-content.rng
@@ -1,0 +1,1544 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <!--
+        This is the Mathematical Markup Language (MathML) 3.0, an XML
+        application for describing mathematical notation and capturing
+        both its structure and content.
+    
+        Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+    
+        Use and distribution of this code are permitted under the terms
+        W3C Software Notice and License
+        http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+  -->
+  <include href="mathml3-strict-content.rng">
+    <define name="cn.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="sep"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="cn.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="base"/>
+      </optional>
+    </define>
+    <define name="ci.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="ci.type"/>
+      </optional>
+    </define>
+    <define name="ci.type">
+      <attribute name="type"/>
+    </define>
+    <define name="ci.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="csymbol.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="cd"/>
+      </optional>
+    </define>
+    <define name="csymbol.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="bvar">
+      <element name="bvar">
+        <ref name="CommonAtt"/>
+        <interleave>
+          <choice>
+            <ref name="ci"/>
+            <ref name="semantics-ci"/>
+          </choice>
+          <optional>
+            <ref name="degree"/>
+          </optional>
+        </interleave>
+      </element>
+    </define>
+    <define name="cbytes.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+    </define>
+    <define name="cs.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+    </define>
+    <define name="apply.content">
+      <choice>
+        <oneOrMore>
+          <ref name="ContExp"/>
+        </oneOrMore>
+        <group>
+          <ref name="ContExp"/>
+          <ref name="BvarQ"/>
+          <zeroOrMore>
+            <ref name="Qualifier"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="ContExp"/>
+          </zeroOrMore>
+        </group>
+      </choice>
+    </define>
+    <define name="bind.content">
+      <ref name="apply.content"/>
+    </define>
+  </include>
+  <define name="base">
+    <attribute name="base"/>
+  </define>
+  <define name="sep">
+    <element name="sep">
+      <empty/>
+    </element>
+  </define>
+  <define name="PresentationExpression" combine="choice">
+    <notAllowed/>
+  </define>
+  <define name="DomainQ">
+    <zeroOrMore>
+      <choice>
+        <ref name="domainofapplication"/>
+        <ref name="condition"/>
+        <ref name="interval"/>
+        <group>
+          <ref name="lowlimit"/>
+          <optional>
+            <ref name="uplimit"/>
+          </optional>
+        </group>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="domainofapplication">
+    <element name="domainofapplication">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="condition">
+    <element name="condition">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="uplimit">
+    <element name="uplimit">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="lowlimit">
+    <element name="lowlimit">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="Qualifier">
+    <choice>
+      <ref name="DomainQ"/>
+      <ref name="degree"/>
+      <ref name="momentabout"/>
+      <ref name="logbase"/>
+    </choice>
+  </define>
+  <define name="degree">
+    <element name="degree">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="momentabout">
+    <element name="momentabout">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="logbase">
+    <element name="logbase">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="type">
+    <attribute name="type"/>
+  </define>
+  <define name="order">
+    <attribute name="order">
+      <choice>
+        <value>numeric</value>
+        <value>lexicographic</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="closure">
+    <attribute name="closure"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="piecewise"/>
+  </define>
+  <define name="piecewise">
+    <element name="piecewise">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="piece"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="otherwise"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="piece">
+    <element name="piece">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="ContExp"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="otherwise">
+    <element name="otherwise">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="DeprecatedContExp">
+    <choice>
+      <ref name="reln"/>
+      <ref name="fn"/>
+      <ref name="declare"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="DeprecatedContExp"/>
+  </define>
+  <define name="reln">
+    <element name="reln">
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="fn">
+    <element name="fn">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="declare">
+    <element name="declare">
+      <optional>
+        <attribute name="type">
+          <data type="string"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="scope">
+          <data type="string"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="nargs">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="occurrence">
+          <choice>
+            <value>prefix</value>
+            <value>infix</value>
+            <value>function-model</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="DefEncAtt"/>
+      <oneOrMore>
+        <ref name="ContExp"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="interval.class">
+    <ref name="interval"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="interval.class"/>
+  </define>
+  <define name="interval">
+    <element name="interval">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="closure"/>
+      </optional>
+      <ref name="ContExp"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="unary-functional.class">
+    <choice>
+      <ref name="inverse"/>
+      <ref name="ident"/>
+      <ref name="domain"/>
+      <ref name="codomain"/>
+      <ref name="image"/>
+      <ref name="ln"/>
+      <ref name="log"/>
+      <ref name="moment"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-functional.class"/>
+  </define>
+  <define name="inverse">
+    <element name="inverse">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ident">
+    <element name="ident">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="domain">
+    <element name="domain">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="codomain">
+    <element name="codomain">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="image">
+    <element name="image">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ln">
+    <element name="ln">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="log">
+    <element name="log">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="moment">
+    <element name="moment">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lambda.class">
+    <ref name="lambda"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="lambda.class"/>
+  </define>
+  <define name="lambda">
+    <element name="lambda">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="nary-functional.class">
+    <ref name="compose"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-functional.class"/>
+  </define>
+  <define name="compose">
+    <element name="compose">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-arith.class">
+    <choice>
+      <ref name="quotient"/>
+      <ref name="divide"/>
+      <ref name="minus"/>
+      <ref name="power"/>
+      <ref name="rem"/>
+      <ref name="root"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-arith.class"/>
+  </define>
+  <define name="quotient">
+    <element name="quotient">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="divide">
+    <element name="divide">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="minus">
+    <element name="minus">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="power">
+    <element name="power">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="rem">
+    <element name="rem">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="root">
+    <element name="root">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-arith.class">
+    <choice>
+      <ref name="factorial"/>
+      <ref name="minus"/>
+      <ref name="root"/>
+      <ref name="abs"/>
+      <ref name="conjugate"/>
+      <ref name="arg"/>
+      <ref name="real"/>
+      <ref name="imaginary"/>
+      <ref name="floor"/>
+      <ref name="ceiling"/>
+      <ref name="exp"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-arith.class"/>
+  </define>
+  <define name="factorial">
+    <element name="factorial">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="abs">
+    <element name="abs">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="conjugate">
+    <element name="conjugate">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arg">
+    <element name="arg">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="real">
+    <element name="real">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="imaginary">
+    <element name="imaginary">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="floor">
+    <element name="floor">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ceiling">
+    <element name="ceiling">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="exp">
+    <element name="exp">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-minmax.class">
+    <choice>
+      <ref name="max"/>
+      <ref name="min"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-minmax.class"/>
+  </define>
+  <define name="max">
+    <element name="max">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="min">
+    <element name="min">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-arith.class">
+    <choice>
+      <ref name="plus"/>
+      <ref name="times"/>
+      <ref name="gcd"/>
+      <ref name="lcm"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-arith.class"/>
+  </define>
+  <define name="plus">
+    <element name="plus">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="times">
+    <element name="times">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="gcd">
+    <element name="gcd">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lcm">
+    <element name="lcm">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-logical.class">
+    <choice>
+      <ref name="and"/>
+      <ref name="or"/>
+      <ref name="xor"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-logical.class"/>
+  </define>
+  <define name="and">
+    <element name="and">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="or">
+    <element name="or">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="xor">
+    <element name="xor">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-logical.class">
+    <ref name="not"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-logical.class"/>
+  </define>
+  <define name="not">
+    <element name="not">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-logical.class">
+    <choice>
+      <ref name="implies"/>
+      <ref name="equivalent"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-logical.class"/>
+  </define>
+  <define name="implies">
+    <element name="implies">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="equivalent">
+    <element name="equivalent">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="quantifier.class">
+    <choice>
+      <ref name="forall"/>
+      <ref name="exists"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="quantifier.class"/>
+  </define>
+  <define name="forall">
+    <element name="forall">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="exists">
+    <element name="exists">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-reln.class">
+    <choice>
+      <ref name="eq"/>
+      <ref name="gt"/>
+      <ref name="lt"/>
+      <ref name="geq"/>
+      <ref name="leq"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-reln.class"/>
+  </define>
+  <define name="eq">
+    <element name="eq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="gt">
+    <element name="gt">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lt">
+    <element name="lt">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="geq">
+    <element name="geq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="leq">
+    <element name="leq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-reln.class">
+    <choice>
+      <ref name="neq"/>
+      <ref name="approx"/>
+      <ref name="factorof"/>
+      <ref name="tendsto"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-reln.class"/>
+  </define>
+  <define name="neq">
+    <element name="neq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="approx">
+    <element name="approx">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="factorof">
+    <element name="factorof">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tendsto">
+    <element name="tendsto">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="type"/>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="int.class">
+    <ref name="int"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="int.class"/>
+  </define>
+  <define name="int">
+    <element name="int">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="Differential-Operator.class">
+    <ref name="diff"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="Differential-Operator.class"/>
+  </define>
+  <define name="diff">
+    <element name="diff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="partialdiff.class">
+    <ref name="partialdiff"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="partialdiff.class"/>
+  </define>
+  <define name="partialdiff">
+    <element name="partialdiff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-veccalc.class">
+    <choice>
+      <ref name="divergence"/>
+      <ref name="grad"/>
+      <ref name="curl"/>
+      <ref name="laplacian"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-veccalc.class"/>
+  </define>
+  <define name="divergence">
+    <element name="divergence">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="grad">
+    <element name="grad">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="curl">
+    <element name="curl">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="laplacian">
+    <element name="laplacian">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-setlist-constructor.class">
+    <choice>
+      <ref name="set"/>
+      <ref name="list"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-setlist-constructor.class"/>
+  </define>
+  <define name="set">
+    <element name="set">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="type"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="BvarQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="DomainQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="list">
+    <element name="list">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="order"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="BvarQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="DomainQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="nary-set.class">
+    <choice>
+      <ref name="union"/>
+      <ref name="intersect"/>
+      <ref name="cartesianproduct"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-set.class"/>
+  </define>
+  <define name="union">
+    <element name="union">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="intersect">
+    <element name="intersect">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cartesianproduct">
+    <element name="cartesianproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-set.class">
+    <choice>
+      <ref name="in"/>
+      <ref name="notin"/>
+      <ref name="notsubset"/>
+      <ref name="notprsubset"/>
+      <ref name="setdiff"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-set.class"/>
+  </define>
+  <define name="in">
+    <element name="in">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notin">
+    <element name="notin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notsubset">
+    <element name="notsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notprsubset">
+    <element name="notprsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="setdiff">
+    <element name="setdiff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-set-reln.class">
+    <choice>
+      <ref name="subset"/>
+      <ref name="prsubset"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-set-reln.class"/>
+  </define>
+  <define name="subset">
+    <element name="subset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="prsubset">
+    <element name="prsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-set.class">
+    <ref name="card"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-set.class"/>
+  </define>
+  <define name="card">
+    <element name="card">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sum.class">
+    <ref name="sum"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="sum.class"/>
+  </define>
+  <define name="sum">
+    <element name="sum">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="product.class">
+    <ref name="product"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="product.class"/>
+  </define>
+  <define name="product">
+    <element name="product">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="limit.class">
+    <ref name="limit"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="limit.class"/>
+  </define>
+  <define name="limit">
+    <element name="limit">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-elementary.class">
+    <choice>
+      <ref name="sin"/>
+      <ref name="cos"/>
+      <ref name="tan"/>
+      <ref name="sec"/>
+      <ref name="csc"/>
+      <ref name="cot"/>
+      <ref name="sinh"/>
+      <ref name="cosh"/>
+      <ref name="tanh"/>
+      <ref name="sech"/>
+      <ref name="csch"/>
+      <ref name="coth"/>
+      <ref name="arcsin"/>
+      <ref name="arccos"/>
+      <ref name="arctan"/>
+      <ref name="arccosh"/>
+      <ref name="arccot"/>
+      <ref name="arccoth"/>
+      <ref name="arccsc"/>
+      <ref name="arccsch"/>
+      <ref name="arcsec"/>
+      <ref name="arcsech"/>
+      <ref name="arcsinh"/>
+      <ref name="arctanh"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-elementary.class"/>
+  </define>
+  <define name="sin">
+    <element name="sin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cos">
+    <element name="cos">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tan">
+    <element name="tan">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sec">
+    <element name="sec">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="csc">
+    <element name="csc">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cot">
+    <element name="cot">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sinh">
+    <element name="sinh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cosh">
+    <element name="cosh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tanh">
+    <element name="tanh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sech">
+    <element name="sech">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="csch">
+    <element name="csch">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="coth">
+    <element name="coth">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsin">
+    <element name="arcsin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccos">
+    <element name="arccos">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arctan">
+    <element name="arctan">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccosh">
+    <element name="arccosh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccot">
+    <element name="arccot">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccoth">
+    <element name="arccoth">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccsc">
+    <element name="arccsc">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccsch">
+    <element name="arccsch">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsec">
+    <element name="arcsec">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsech">
+    <element name="arcsech">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsinh">
+    <element name="arcsinh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arctanh">
+    <element name="arctanh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-stats.class">
+    <choice>
+      <ref name="mean"/>
+      <ref name="sdev"/>
+      <ref name="variance"/>
+      <ref name="median"/>
+      <ref name="mode"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-stats.class"/>
+  </define>
+  <define name="mean">
+    <element name="mean">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sdev">
+    <element name="sdev">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="variance">
+    <element name="variance">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="median">
+    <element name="median">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mode">
+    <element name="mode">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-constructor.class">
+    <choice>
+      <ref name="vector"/>
+      <ref name="matrix"/>
+      <ref name="matrixrow"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-constructor.class"/>
+  </define>
+  <define name="vector">
+    <element name="vector">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="matrix">
+    <element name="matrix">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="matrixrow">
+    <element name="matrixrow">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="unary-linalg.class">
+    <choice>
+      <ref name="determinant"/>
+      <ref name="transpose"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-linalg.class"/>
+  </define>
+  <define name="determinant">
+    <element name="determinant">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="transpose">
+    <element name="transpose">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-linalg.class">
+    <ref name="selector"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-linalg.class"/>
+  </define>
+  <define name="selector">
+    <element name="selector">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-linalg.class">
+    <choice>
+      <ref name="vectorproduct"/>
+      <ref name="scalarproduct"/>
+      <ref name="outerproduct"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-linalg.class"/>
+  </define>
+  <define name="vectorproduct">
+    <element name="vectorproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="scalarproduct">
+    <element name="scalarproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="outerproduct">
+    <element name="outerproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="constant-set.class">
+    <choice>
+      <ref name="integers"/>
+      <ref name="reals"/>
+      <ref name="rationals"/>
+      <ref name="naturalnumbers"/>
+      <ref name="complexes"/>
+      <ref name="primes"/>
+      <ref name="emptyset"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="constant-set.class"/>
+  </define>
+  <define name="integers">
+    <element name="integers">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="reals">
+    <element name="reals">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="rationals">
+    <element name="rationals">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="naturalnumbers">
+    <element name="naturalnumbers">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="complexes">
+    <element name="complexes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="primes">
+    <element name="primes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="emptyset">
+    <element name="emptyset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="constant-arith.class">
+    <choice>
+      <ref name="exponentiale"/>
+      <ref name="imaginaryi"/>
+      <ref name="notanumber"/>
+      <ref name="true"/>
+      <ref name="false"/>
+      <ref name="pi"/>
+      <ref name="eulergamma"/>
+      <ref name="infinity"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="constant-arith.class"/>
+  </define>
+  <define name="exponentiale">
+    <element name="exponentiale">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="imaginaryi">
+    <element name="imaginaryi">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notanumber">
+    <element name="notanumber">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="true">
+    <element name="true">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="false">
+    <element name="false">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="pi">
+    <element name="pi">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="eulergamma">
+    <element name="eulergamma">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="infinity">
+    <element name="infinity">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+</grammar>

--- a/lib/metanorma/iho/mathml3-presentation.rng
+++ b/lib/metanorma/iho/mathml3-presentation.rng
@@ -1,0 +1,2324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="MathExpression" combine="choice">
+    <ref name="PresentationExpression"/>
+  </define>
+  <define name="ImpliedMrow">
+    <zeroOrMore>
+      <ref name="MathExpression"/>
+    </zeroOrMore>
+  </define>
+  <define name="TableRowExpression">
+    <choice>
+      <ref name="mtr"/>
+      <ref name="mlabeledtr"/>
+    </choice>
+  </define>
+  <define name="TableCellExpression">
+    <ref name="mtd"/>
+  </define>
+  <define name="MstackExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="mscarries"/>
+      <ref name="msline"/>
+      <ref name="msrow"/>
+      <ref name="msgroup"/>
+    </choice>
+  </define>
+  <define name="MsrowExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+  </define>
+  <define name="MultiScriptExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+  </define>
+  <define name="mpadded-length">
+    <data type="string">
+      <param name="pattern">\s*([\+\-]?[0-9]*([0-9]\.?|\.[0-9])[0-9]*\s*((%?\s*(height|depth|width)?)|e[mx]|in|cm|mm|p[xtc]|((negative)?((very){0,2}thi(n|ck)|medium)mathspace))?)\s*</param>
+    </data>
+  </define>
+  <define name="linestyle">
+    <choice>
+      <value>none</value>
+      <value>solid</value>
+      <value>dashed</value>
+    </choice>
+  </define>
+  <define name="verticalalign">
+    <choice>
+      <value>top</value>
+      <value>bottom</value>
+      <value>center</value>
+      <value>baseline</value>
+      <value>axis</value>
+    </choice>
+  </define>
+  <define name="columnalignstyle">
+    <choice>
+      <value>left</value>
+      <value>center</value>
+      <value>right</value>
+    </choice>
+  </define>
+  <define name="notationstyle">
+    <choice>
+      <value>longdiv</value>
+      <value>actuarial</value>
+      <value>radical</value>
+      <value>box</value>
+      <value>roundedbox</value>
+      <value>circle</value>
+      <value>left</value>
+      <value>right</value>
+      <value>top</value>
+      <value>bottom</value>
+      <value>updiagonalstrike</value>
+      <value>downdiagonalstrike</value>
+      <value>verticalstrike</value>
+      <value>horizontalstrike</value>
+      <value>madruwb</value>
+    </choice>
+  </define>
+  <define name="idref">
+    <text/>
+  </define>
+  <define name="unsigned-integer">
+    <data type="unsignedLong"/>
+  </define>
+  <define name="integer">
+    <data type="integer"/>
+  </define>
+  <define name="number">
+    <data type="decimal"/>
+  </define>
+  <define name="character">
+    <data type="string">
+      <param name="pattern">\s*\S\s*</param>
+    </data>
+  </define>
+  <define name="color">
+    <data type="string">
+      <param name="pattern">\s*((#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?)|[aA][qQ][uU][aA]|[bB][lL][aA][cC][kK]|[bB][lL][uU][eE]|[fF][uU][cC][hH][sS][iI][aA]|[gG][rR][aA][yY]|[gG][rR][eE][eE][nN]|[lL][iI][mM][eE]|[mM][aA][rR][oO][oO][nN]|[nN][aA][vV][yY]|[oO][lL][iI][vV][eE]|[pP][uU][rR][pP][lL][eE]|[rR][eE][dD]|[sS][iI][lL][vV][eE][rR]|[tT][eE][aA][lL]|[wW][hH][iI][tT][eE]|[yY][eE][lL][lL][oO][wW])\s*</param>
+    </data>
+  </define>
+  <define name="group-alignment">
+    <choice>
+      <value>left</value>
+      <value>center</value>
+      <value>right</value>
+      <value>decimalpoint</value>
+    </choice>
+  </define>
+  <define name="group-alignment-list">
+    <list>
+      <oneOrMore>
+        <ref name="group-alignment"/>
+      </oneOrMore>
+    </list>
+  </define>
+  <define name="group-alignment-list-list">
+    <data type="string">
+      <param name="pattern">(\s*\{\s*(left|center|right|decimalpoint)(\s+(left|center|right|decimalpoint))*\})*\s*</param>
+    </data>
+  </define>
+  <define name="positive-integer">
+    <data type="positiveInteger"/>
+  </define>
+  <define name="TokenExpression">
+    <choice>
+      <ref name="mi"/>
+      <ref name="mn"/>
+      <ref name="mo"/>
+      <ref name="mtext"/>
+      <ref name="mspace"/>
+      <ref name="ms"/>
+    </choice>
+  </define>
+  <define name="token.content">
+    <choice>
+      <ref name="mglyph"/>
+      <ref name="malignmark"/>
+      <text/>
+    </choice>
+  </define>
+  <define name="mi">
+    <element name="mi">
+      <ref name="mi.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mi.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mn">
+    <element name="mn">
+      <ref name="mn.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mn.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mo">
+    <element name="mo">
+      <ref name="mo.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mo.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="form">
+        <choice>
+          <value>prefix</value>
+          <value>infix</value>
+          <value>postfix</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fence">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separator">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stretchy">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="symmetric">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxsize">
+        <choice>
+          <ref name="length"/>
+          <value>infinity</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="largeop">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="movablelimits">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lineleading">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+          <value>infixlinebreakstyle</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakmultchar"/>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mtext">
+    <element name="mtext">
+      <ref name="mtext.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtext.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mspace">
+    <element name="mspace">
+      <ref name="mspace.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mspace.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+          <value>indentingnewline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="ms">
+    <element name="ms">
+      <ref name="ms.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="ms.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="lquote"/>
+    </optional>
+    <optional>
+      <attribute name="rquote"/>
+    </optional>
+  </define>
+  <define name="mglyph">
+    <element name="mglyph">
+      <ref name="mglyph.attributes"/>
+      <ref name="mglyph.deprecatedattributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mglyph.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="src">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="valign">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+  </define>
+  <define name="mglyph.deprecatedattributes">
+    <optional>
+      <attribute name="index">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="DeprecatedTokenAtt"/>
+  </define>
+  <define name="msline">
+    <element name="msline">
+      <ref name="msline.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="msline.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="length">
+        <ref name="unsigned-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="leftoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rightoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mslinethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="none">
+    <element name="none">
+      <ref name="none.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="none.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mprescripts">
+    <element name="mprescripts">
+      <ref name="mprescripts.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mprescripts.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="CommonPresAtt">
+    <optional>
+      <attribute name="mathcolor">
+        <ref name="color"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathbackground">
+        <choice>
+          <ref name="color"/>
+          <value>transparent</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="TokenAtt">
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="DeprecatedTokenAtt"/>
+  </define>
+  <define name="DeprecatedTokenAtt">
+    <optional>
+      <attribute name="fontfamily"/>
+    </optional>
+    <optional>
+      <attribute name="fontweight">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fontstyle">
+        <choice>
+          <value>normal</value>
+          <value>italic</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fontsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="color">
+        <ref name="color"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="background">
+        <choice>
+          <ref name="color"/>
+          <value>transparent</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="MalignExpression">
+    <choice>
+      <ref name="maligngroup"/>
+      <ref name="malignmark"/>
+    </choice>
+  </define>
+  <define name="malignmark">
+    <element name="malignmark">
+      <ref name="malignmark.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="malignmark.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="edge">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="maligngroup">
+    <element name="maligngroup">
+      <ref name="maligngroup.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="maligngroup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="groupalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="PresentationExpression">
+    <choice>
+      <ref name="TokenExpression"/>
+      <ref name="MalignExpression"/>
+      <ref name="mrow"/>
+      <ref name="mfrac"/>
+      <ref name="msqrt"/>
+      <ref name="mroot"/>
+      <ref name="mstyle"/>
+      <ref name="merror"/>
+      <ref name="mpadded"/>
+      <ref name="mphantom"/>
+      <ref name="mfenced"/>
+      <ref name="menclose"/>
+      <ref name="msub"/>
+      <ref name="msup"/>
+      <ref name="msubsup"/>
+      <ref name="munder"/>
+      <ref name="mover"/>
+      <ref name="munderover"/>
+      <ref name="mmultiscripts"/>
+      <ref name="mtable"/>
+      <ref name="mstack"/>
+      <ref name="mlongdiv"/>
+      <ref name="maction"/>
+    </choice>
+  </define>
+  <define name="mrow">
+    <element name="mrow">
+      <ref name="mrow.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mrow.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mfrac">
+    <element name="mfrac">
+      <ref name="mfrac.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mfrac.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="linethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="numalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="denomalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="bevelled">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msqrt">
+    <element name="msqrt">
+      <ref name="msqrt.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="msqrt.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mroot">
+    <element name="mroot">
+      <ref name="mroot.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mroot.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mstyle">
+    <element name="mstyle">
+      <ref name="mstyle.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mstyle.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="mstyle.specificattributes"/>
+    <ref name="mstyle.generalattributes"/>
+    <ref name="mstyle.deprecatedattributes"/>
+  </define>
+  <define name="mstyle.specificattributes">
+    <optional>
+      <attribute name="scriptlevel">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="displaystyle">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptsizemultiplier">
+        <ref name="number"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptminsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="infixlinebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="decimalpoint">
+        <ref name="character"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstyle.generalattributes">
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alignmentscope">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="bevelled">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charspacing">
+        <choice>
+          <ref name="length"/>
+          <value>loose</value>
+          <value>medium</value>
+          <value>tight</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="close"/>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnwidth">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>auto</value>
+              <ref name="length"/>
+              <value>fit</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="denomalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="edge">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalcolumns">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalrows">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fence">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="form">
+        <choice>
+          <value>prefix</value>
+          <value>infix</value>
+          <value>postfix</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="frame">
+        <ref name="linestyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="framespacing">
+        <list>
+          <ref name="length"/>
+          <ref name="length"/>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="largeop">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="leftoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="length">
+        <ref name="unsigned-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakmultchar"/>
+    </optional>
+    <optional>
+      <attribute name="linebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+          <value>infixlinebreakstyle</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lineleading">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="longdivstyle">
+        <choice>
+          <value>lefttop</value>
+          <value>stackedrightright</value>
+          <value>mediumstackedrightright</value>
+          <value>shortstackedrightright</value>
+          <value>righttop</value>
+          <value>left/\right</value>
+          <value>left)(right</value>
+          <value>:right=right</value>
+          <value>stackedleftleft</value>
+          <value>stackedleftlinetop</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lquote"/>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxsize">
+        <choice>
+          <ref name="length"/>
+          <value>infinity</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minlabelspacing">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="movablelimits">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mslinethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="notation"/>
+    </optional>
+    <optional>
+      <attribute name="numalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="open"/>
+    </optional>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rightoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <list>
+          <oneOrMore>
+            <ref name="verticalalign"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rquote"/>
+    </optional>
+    <optional>
+      <attribute name="rspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="selection">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separator">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separators"/>
+    </optional>
+    <optional>
+      <attribute name="shift">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="side">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>leftoverlap</value>
+          <value>rightoverlap</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stackalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stretchy">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="symmetric">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="valign">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstyle.deprecatedattributes">
+    <ref name="DeprecatedTokenAtt"/>
+    <optional>
+      <attribute name="veryverythinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="verythinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="thinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mediummathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="thickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="verythickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="veryverythickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="mstyle.specificattributes"/>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="mstyle.generalattributes"/>
+  </define>
+  <define name="merror">
+    <element name="merror">
+      <ref name="merror.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="merror.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mpadded">
+    <element name="mpadded">
+      <ref name="mpadded.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mpadded.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="height">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="voffset">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mphantom">
+    <element name="mphantom">
+      <ref name="mphantom.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mphantom.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mfenced">
+    <element name="mfenced">
+      <ref name="mfenced.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mfenced.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="open"/>
+    </optional>
+    <optional>
+      <attribute name="close"/>
+    </optional>
+    <optional>
+      <attribute name="separators"/>
+    </optional>
+  </define>
+  <define name="menclose">
+    <element name="menclose">
+      <ref name="menclose.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="menclose.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="notation"/>
+    </optional>
+  </define>
+  <define name="msub">
+    <element name="msub">
+      <ref name="msub.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msub.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msup">
+    <element name="msup">
+      <ref name="msup.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msubsup">
+    <element name="msubsup">
+      <ref name="msubsup.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msubsup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="munder">
+    <element name="munder">
+      <ref name="munder.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="munder.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mover">
+    <element name="mover">
+      <ref name="mover.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mover.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="munderover">
+    <element name="munderover">
+      <ref name="munderover.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="munderover.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mmultiscripts">
+    <element name="mmultiscripts">
+      <ref name="mmultiscripts.attributes"/>
+      <ref name="MathExpression"/>
+      <zeroOrMore>
+        <ref name="MultiScriptExpression"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="mprescripts"/>
+        <zeroOrMore>
+          <ref name="MultiScriptExpression"/>
+        </zeroOrMore>
+      </optional>
+    </element>
+  </define>
+  <define name="mmultiscripts.attributes">
+    <ref name="msubsup.attributes"/>
+  </define>
+  <define name="mtable">
+    <element name="mtable">
+      <ref name="mtable.attributes"/>
+      <zeroOrMore>
+        <ref name="TableRowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtable.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="align">
+        <data type="string">
+          <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+        </data>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <list>
+          <oneOrMore>
+            <ref name="verticalalign"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alignmentscope">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnwidth">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>auto</value>
+              <ref name="length"/>
+              <value>fit</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <choice>
+          <value>auto</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="frame">
+        <ref name="linestyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="framespacing">
+        <list>
+          <ref name="length"/>
+          <ref name="length"/>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalrows">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalcolumns">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="displaystyle">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="side">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>leftoverlap</value>
+          <value>rightoverlap</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minlabelspacing">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mlabeledtr">
+    <element name="mlabeledtr">
+      <ref name="mlabeledtr.attributes"/>
+      <oneOrMore>
+        <ref name="TableCellExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mlabeledtr.attributes">
+    <ref name="mtr.attributes"/>
+  </define>
+  <define name="mtr">
+    <element name="mtr">
+      <ref name="mtr.attributes"/>
+      <zeroOrMore>
+        <ref name="TableCellExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtr.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="rowalign">
+        <choice>
+          <value>top</value>
+          <value>bottom</value>
+          <value>center</value>
+          <value>baseline</value>
+          <value>axis</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mtd">
+    <element name="mtd">
+      <ref name="mtd.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mtd.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="rowspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <choice>
+          <value>top</value>
+          <value>bottom</value>
+          <value>center</value>
+          <value>baseline</value>
+          <value>axis</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <ref name="columnalignstyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstack">
+    <element name="mstack">
+      <ref name="mstack.attributes"/>
+      <zeroOrMore>
+        <ref name="MstackExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mstack.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="align">
+        <data type="string">
+          <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+        </data>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stackalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charspacing">
+        <choice>
+          <ref name="length"/>
+          <value>loose</value>
+          <value>medium</value>
+          <value>tight</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mlongdiv">
+    <element name="mlongdiv">
+      <ref name="mlongdiv.attributes"/>
+      <ref name="MstackExpression"/>
+      <ref name="MstackExpression"/>
+      <oneOrMore>
+        <ref name="MstackExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mlongdiv.attributes">
+    <ref name="msgroup.attributes"/>
+    <optional>
+      <attribute name="longdivstyle">
+        <choice>
+          <value>lefttop</value>
+          <value>stackedrightright</value>
+          <value>mediumstackedrightright</value>
+          <value>shortstackedrightright</value>
+          <value>righttop</value>
+          <value>left/\right</value>
+          <value>left)(right</value>
+          <value>:right=right</value>
+          <value>stackedleftleft</value>
+          <value>stackedleftlinetop</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msgroup">
+    <element name="msgroup">
+      <ref name="msgroup.attributes"/>
+      <zeroOrMore>
+        <ref name="MstackExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="msgroup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="shift">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msrow">
+    <element name="msrow">
+      <ref name="msrow.attributes"/>
+      <zeroOrMore>
+        <ref name="MsrowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="msrow.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mscarries">
+    <element name="mscarries">
+      <ref name="mscarries.attributes"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MsrowExpression"/>
+          <ref name="mscarry"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mscarries.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptsizemultiplier">
+        <ref name="number"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mscarry">
+    <element name="mscarry">
+      <ref name="mscarry.attributes"/>
+      <zeroOrMore>
+        <ref name="MsrowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mscarry.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="maction">
+    <element name="maction">
+      <ref name="maction.attributes"/>
+      <oneOrMore>
+        <ref name="MathExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="maction.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <attribute name="actiontype"/>
+    <optional>
+      <attribute name="selection">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+  </define>
+</grammar>

--- a/lib/metanorma/iho/mathml3-strict-content.rng
+++ b/lib/metanorma/iho/mathml3-strict-content.rng
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="ContExp">
+    <choice>
+      <ref name="semantics-contexp"/>
+      <ref name="cn"/>
+      <ref name="ci"/>
+      <ref name="csymbol"/>
+      <ref name="apply"/>
+      <ref name="bind"/>
+      <ref name="share"/>
+      <ref name="cerror"/>
+      <ref name="cbytes"/>
+      <ref name="cs"/>
+    </choice>
+  </define>
+  <define name="cn">
+    <element name="cn">
+      <ref name="cn.attributes"/>
+      <ref name="cn.content"/>
+    </element>
+  </define>
+  <define name="cn.content">
+    <text/>
+  </define>
+  <define name="cn.attributes">
+    <ref name="CommonAtt"/>
+    <attribute name="type">
+      <choice>
+        <value>integer</value>
+        <value>real</value>
+        <value>double</value>
+        <value>hexdouble</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="semantics-ci">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <choice>
+        <ref name="ci"/>
+        <ref name="semantics-ci"/>
+      </choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="semantics-contexp">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <ref name="ContExp"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="ci">
+    <element name="ci">
+      <ref name="ci.attributes"/>
+      <ref name="ci.content"/>
+    </element>
+  </define>
+  <define name="ci.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <ref name="ci.type"/>
+    </optional>
+  </define>
+  <define name="ci.type">
+    <attribute name="type">
+      <choice>
+        <value>integer</value>
+        <value>rational</value>
+        <value>real</value>
+        <value>complex</value>
+        <value>complex-polar</value>
+        <value>complex-cartesian</value>
+        <value>constant</value>
+        <value>function</value>
+        <value>vector</value>
+        <value>list</value>
+        <value>set</value>
+        <value>matrix</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="ci.content">
+    <text/>
+  </define>
+  <define name="csymbol">
+    <element name="csymbol">
+      <ref name="csymbol.attributes"/>
+      <ref name="csymbol.content"/>
+    </element>
+  </define>
+  <define name="SymbolName">
+    <data type="NCName"/>
+  </define>
+  <define name="csymbol.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="cd"/>
+  </define>
+  <define name="csymbol.content">
+    <ref name="SymbolName"/>
+  </define>
+  <define name="BvarQ">
+    <zeroOrMore>
+      <ref name="bvar"/>
+    </zeroOrMore>
+  </define>
+  <define name="bvar">
+    <element name="bvar">
+      <ref name="CommonAtt"/>
+      <choice>
+        <ref name="ci"/>
+        <ref name="semantics-ci"/>
+      </choice>
+    </element>
+  </define>
+  <define name="apply">
+    <element name="apply">
+      <ref name="CommonAtt"/>
+      <ref name="apply.content"/>
+    </element>
+  </define>
+  <define name="apply.content">
+    <oneOrMore>
+      <ref name="ContExp"/>
+    </oneOrMore>
+  </define>
+  <define name="bind">
+    <element name="bind">
+      <ref name="CommonAtt"/>
+      <ref name="bind.content"/>
+    </element>
+  </define>
+  <define name="bind.content">
+    <ref name="ContExp"/>
+    <zeroOrMore>
+      <ref name="bvar"/>
+    </zeroOrMore>
+    <ref name="ContExp"/>
+  </define>
+  <define name="share">
+    <element name="share">
+      <ref name="CommonAtt"/>
+      <ref name="src"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cerror">
+    <element name="cerror">
+      <ref name="cerror.attributes"/>
+      <ref name="csymbol"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="cerror.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="cbytes">
+    <element name="cbytes">
+      <ref name="cbytes.attributes"/>
+      <ref name="base64"/>
+    </element>
+  </define>
+  <define name="cbytes.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="base64">
+    <data type="base64Binary"/>
+  </define>
+  <define name="cs">
+    <element name="cs">
+      <ref name="cs.attributes"/>
+      <text/>
+    </element>
+  </define>
+  <define name="cs.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="MathExpression" combine="choice">
+    <ref name="ContExp"/>
+  </define>
+</grammar>

--- a/lib/metanorma/iho/mathml3.rng
+++ b/lib/metanorma/iho/mathml3.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2010 W3C (MIT, ERCIM, Keio)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="mathml3-content.rng">
+    <a:documentation>Content  MathML</a:documentation>
+  </include>
+  <include href="mathml3-presentation.rng">
+    <a:documentation>Presentation MathML</a:documentation>
+  </include>
+  <include href="mathml3-common.rng">
+    <a:documentation>math and semantics common to both Content and Presentation</a:documentation>
+  </include>
+</grammar>

--- a/lib/metanorma/iho/metanorma-mathml.rng
+++ b/lib/metanorma/iho/metanorma-mathml.rng
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <!--
+    Metanorma wrapper around the vendored W3C MathML 3.0 RelaxNG grammar.
+    Includes the unmodified W3C grammar (start = math) and augments it with
+    metanorma's owned extension attributes. Referenced from basicdoc.rnc via:
+      mathml = external "mathml/metanorma-mathml.rnc"
+    Authoritative param list for data-metanorma-numberformat lives in plurimath
+    (Formatter::Standard::DEFAULT_OPTIONS); see metanorma/basicdoc-models#35.
+  -->
+  <include href="mathml3.rng"/>
+  <!--
+    metanorma number-formatting hint on <mn>; opaque comma-separated option
+    string parsed at presentation time (no-namespace data- attribute, which
+    the W3C CommonAtt/NonMathMLAtt does not otherwise permit).
+  -->
+  <define name="mn.attributes" combine="interleave">
+    <optional>
+      <attribute name="data-metanorma-numberformat"/>
+    </optional>
+  </define>
+</grammar>

--- a/lib/metanorma/iho/metanorma-mathml.rng
+++ b/lib/metanorma/iho/metanorma-mathml.rng
@@ -8,24 +8,7 @@
     Authoritative param list for data-metanorma-numberformat lives in plurimath
     (Formatter::Standard::DEFAULT_OPTIONS); see metanorma/basicdoc-models#35.
   -->
-  <include href="mathml3.rng">
-    <!--
-      Foreign annotation-xml considered harmful: the metanorma lutaml-model
-      serialiser emits no foreign markup, so the W3C annotation-xml escape hatch
-      (and its anyElement wildcard) is forbidden in the MathML we process. This
-      also removes the untyped `id` attribute the wildcard permits, which clashes
-      with xsd:ID under RELAX NG ID-type consistency (the callout-annotation
-      error). metanorma only emits presentation MathML; pre-empting the escape
-      hatch before semantic MathML is ever wired. Text-only <annotation> is
-      retained. See metanorma/basicdoc-models#35
-    -->
-    <define name="annotation-xml">
-      <notAllowed/>
-    </define>
-    <define name="anyElement">
-      <notAllowed/>
-    </define>
-  </include>
+  <include href="mathml3.rng"/>
   <!--
     metanorma number-formatting hint on <mn>; opaque comma-separated option
     string parsed at presentation time (no-namespace data- attribute, which
@@ -35,5 +18,28 @@
     <optional>
       <attribute name="data-metanorma-numberformat"/>
     </optional>
+  </define>
+  <!--
+    Foreign annotation-xml considered harmful: the metanorma lutaml-model
+    serialiser emits no foreign markup, so the W3C annotation-xml escape hatch
+    (and its anyElement wildcard) is forbidden in the MathML we process. This
+    also removes the untyped `id` attribute the wildcard permits, which clashes
+    with xsd:ID under RELAX NG ID-type consistency (the callout-annotation error).
+    metanorma only emits presentation MathML; pre-empting the escape hatch before
+    semantic MathML is ever wired. Text-only <annotation> is retained.
+    
+    Expressed via `combine` (interleave with notAllowed) rather than an
+    include-override: annotation-xml/anyElement are defined in the transitively
+    included mathml3-common, and libxml2's RelaxNG (used by Nokogiri for fragment
+    / passthrough validation) cannot override a define from a nested include - -
+    it demands the combine attribute and otherwise fails to compile the whole
+    grammar (every passthrough then wrongly reports "Invalid passthrough
+    content"). jing accepts both forms; combine satisfies both. basicdoc-models#35
+  -->
+  <define name="annotation-xml" combine="interleave">
+    <notAllowed/>
+  </define>
+  <define name="anyElement" combine="interleave">
+    <notAllowed/>
   </define>
 </grammar>

--- a/lib/metanorma/iho/metanorma-mathml.rng
+++ b/lib/metanorma/iho/metanorma-mathml.rng
@@ -8,7 +8,24 @@
     Authoritative param list for data-metanorma-numberformat lives in plurimath
     (Formatter::Standard::DEFAULT_OPTIONS); see metanorma/basicdoc-models#35.
   -->
-  <include href="mathml3.rng"/>
+  <include href="mathml3.rng">
+    <!--
+      Foreign annotation-xml considered harmful: the metanorma lutaml-model
+      serialiser emits no foreign markup, so the W3C annotation-xml escape hatch
+      (and its anyElement wildcard) is forbidden in the MathML we process. This
+      also removes the untyped `id` attribute the wildcard permits, which clashes
+      with xsd:ID under RELAX NG ID-type consistency (the callout-annotation
+      error). metanorma only emits presentation MathML; pre-empting the escape
+      hatch before semantic MathML is ever wired. Text-only <annotation> is
+      retained. See metanorma/basicdoc-models#35
+    -->
+    <define name="annotation-xml">
+      <notAllowed/>
+    </define>
+    <define name="anyElement">
+      <notAllowed/>
+    </define>
+  </include>
   <!--
     metanorma number-formatting hint on <mn>; opaque comma-separated option
     string parsed at presentation time (no-namespace data- attribute, which

--- a/lib/metanorma/iho/reqt.rng
+++ b/lib/metanorma/iho/reqt.rng
@@ -39,7 +39,11 @@ the tag name of the top level containers</a:documentation>
       <data type="ID"/>
     </attribute>
     <ref name="NumberingAttributes"/>
-    <ref name="BlockAttributes"/>
+    <ref name="BlockAttributesCore">
+      <a:documentation>requirement carries its own semantic `class` (provision class, below), so
+it uses BlockAttributesCore to avoid duplicating the custom-class slot now
+in BlockAttributes. See metanorma/metanorma-standoc#1197</a:documentation>
+    </ref>
     <optional>
       <attribute name="filename">
         <a:documentation>File name of the requirement model when exported</a:documentation>
@@ -225,7 +229,11 @@ machine-readable, and is not to be rendered as document output</a:documentation>
         <data type="boolean"/>
       </attribute>
     </optional>
-    <ref name="BlockAttributes"/>
+    <ref name="BlockAttributesCore">
+      <a:documentation>component (a RequirementSubpart) carries its own semantic `class`, so this
+uses BlockAttributesCore to avoid duplicating the custom-class slot in
+BlockAttributes. See metanorma/metanorma-standoc#1197</a:documentation>
+    </ref>
     <oneOrMore>
       <choice>
         <a:documentation>Content of subpart: blocks, rather than provisions</a:documentation>


### PR DESCRIPTION
Refs https://github.com/metanorma/basicdoc-models/issues/35

- updated `basicdoc.rng` + companion `metanorma-mathml.rng`/`mathml3*.rng` — the explicit W3C MathML 3 grammar (from metanorma-model-iso's universal compile)
- `Gemfile.devel`: pin `metanorma-standoc` to main as a **bridge** — the new grammar needs standoc's `id_check: false` fix (jing namespace-blind ID-type conflict), merged but not yet released. **Remove the pin and bump the released standoc on release.**

Design note + the gotcha are on basicdoc-models#35. Verified end-to-end: a MathML document validates with no ID conflict.

🤖
